### PR TITLE
Bugfix: Define optional 'properties' property if not present

### DIFF
--- a/WebGLLayer.js
+++ b/WebGLLayer.js
@@ -469,6 +469,7 @@ WebGLLayer.prototype.loadPointData = function(feature, geometry){
   this.features_.points.floats.push(xy[1]);
   this.features_.points.floats.push(WebGLLayer.packColor(this.features_.points.defaultColor));
 
+  if (!feature.hasOwnProperty('properties')) feature.properties = {};
   feature.properties.index = this.features_.points.count++;
 
   this.features_.points.changed = true;


### PR DESCRIPTION
GeoJSON Point features require `type` and `coordinates` properties, but `properties` is optional. The current `loadPointData` method assumes that `features.properties` will exist and errors on the `features.properties.index` assignment if `features.properties` is not present. This fix initializes `features.properties` as an empty object if not present so the assignment on the next line should always work.
