### PR TITLE
Custom point size

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,4 +112,6 @@ You can then run powerful queries on the data and use the index property on the 
 var result = ... //Query result.
 var idx = result.properties.index;
 myLayer.changePointColor(idx, [0., 0., 1.]); //Change color to blue
+myLayer.changePointSize(4);
+myLayer.start();
 ```

--- a/WebGLLayer.js
+++ b/WebGLLayer.js
@@ -168,22 +168,23 @@ WebGLLayer.DEFAULT_POINT_FRAG_SHADER_ = [
  * Default vertex shader source.
  * @private {string}
  */
-WebGLLayer.DEFAULT_POINT_VERT_SHADER_ = [
+WebGLLayer.vertShaderConfig_ = function(size){
+  size = size || 2;
+  return [
     'precision mediump float;',
-
     'attribute vec4 worldCoord;',
     'attribute float aColor;',
-
     'uniform mat4 mapMatrix;',
-
     'varying mediump float vColor;',
-
     'void main() {',
     '  gl_Position = mapMatrix * worldCoord;',
-    '  gl_PointSize = 2.;',
+    '  gl_PointSize = ' + size + '.;',
     '  vColor = aColor;',
     '}'
-].join('\n');
+  ].join('\n');
+}
+
+WebGLLayer.DEFAULT_POINT_VERT_SHADER_ = WebGLLayer.vertShaderConfig_(2);
 
 /**
  * Converts from latitude to vertical world coordinate.
@@ -367,6 +368,13 @@ WebGLLayer.prototype.changePointColor = function(idx, color){
   this.features_.points.floats[idx*3 + 2] = WebGLLayer.packColor(color);
   this.features_.points.changed = true;
   this.scheduleUpdate();
+}
+
+WebGLLayer.prototype.changePointSize = function(size){
+  if (typeof size !== 'number') return console.log("Error: customPointSize expects number input");
+
+  WebGLLayer.DEFAULT_POINT_VERT_SHADER_ = WebGLLayer.vertShaderConfig_(size);
+  this.pointProgram_ = new ShaderProgram(this.gl_, WebGLLayer.DEFAULT_POINT_VERT_SHADER_, WebGLLayer.DEFAULT_POINT_FRAG_SHADER_);
 }
 
 /**


### PR DESCRIPTION
Adds a `changePointSize` method so users can specify a custom point size. (It currently defaults to 2.) Example usage:

```
// define mapCanvas and mapOptions as in demo
map = new google.maps.Map(mapCanvas, mapOptions);
var myLayer = new WebGLLayer(map);
myLayer.changePointSize(4);
myLayer.start();
```

Closes #3 (cc: @korczis)
